### PR TITLE
Improve Main View UI

### DIFF
--- a/PlayNext/Infrastructure/Converters/ShowcaseTypeToBooleanConverter.cs
+++ b/PlayNext/Infrastructure/Converters/ShowcaseTypeToBooleanConverter.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Globalization;
+using System.Windows.Data;
+using PlayNext.Model.Data;
+
+namespace PlayNext.Infrastructure.Converters
+{
+    internal class ShowcaseTypeToBooleanConverter : BaseConverter, IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is ShowcaseType selectedType &&
+                parameter is ShowcaseType showcaseType)
+            {
+                return selectedType == showcaseType;
+            }
+
+            return false;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/PlayNext/PlayNext.csproj
+++ b/PlayNext/PlayNext.csproj
@@ -61,6 +61,7 @@
     <Compile Include="Infrastructure\Converters\BaseConverter.cs" />
     <Compile Include="Infrastructure\Converters\BooleanToCollapsedVisibilityConverter.cs" />
     <Compile Include="Infrastructure\Converters\InvertedBooleanToCollapsedVisibilityConverter.cs" />
+    <Compile Include="Infrastructure\Converters\ShowcaseTypeToBooleanConverter.cs" />
     <Compile Include="Infrastructure\Converters\ShowcaseTypeToCollapsedVisibilityConverter.cs" />
     <Compile Include="Infrastructure\Converters\ShowcaseTypeToInvertedBooleanConverter.cs" />
     <Compile Include="Infrastructure\Converters\UriToBitmapImageConverter.cs" />

--- a/PlayNext/ViewModels/PlayNextMainViewModel.cs
+++ b/PlayNext/ViewModels/PlayNextMainViewModel.cs
@@ -60,7 +60,9 @@ namespace PlayNext.ViewModels
 		// ReSharper disable once UnusedMember.Global
 		public ICommand SwitchToList => new RelayCommand(() => { ActiveShowcaseType = ShowcaseType.List; });
 
-		public void LoadData(ICollection<GameToPlayViewModel> games, PlayNextSettings settings)
+        public ICommand NavigateBackCommand => new RelayCommand(() => { API.Instance.MainView.SwitchToLibraryView(); });
+
+        public void LoadData(ICollection<GameToPlayViewModel> games, PlayNextSettings settings)
 		{
 			new Task(() =>
 			{

--- a/PlayNext/Views/PlayNextMainView.xaml
+++ b/PlayNext/Views/PlayNextMainView.xaml
@@ -39,19 +39,17 @@
         </ResourceDictionary>
     </PluginUserControl.Resources>
 
-    <Grid>
-        <Grid.RowDefinitions>
-            <RowDefinition Height="50px"></RowDefinition>
-            <RowDefinition Height="50px"></RowDefinition>
-            <RowDefinition Height="*"></RowDefinition>
-        </Grid.RowDefinitions>
-        <TextBlock Grid.Row="0" 
-                   Text="{DynamicResource LOC_PlayNext_PluginName}" 
-                   Style="{StaticResource BaseTextBlockStyle}"
-                   FontSize="18"
-                   Margin="10,30,0,0"
-                   VerticalAlignment="Center"></TextBlock>
-        <StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Right">
+    <DockPanel>
+        <StackPanel Orientation="Horizontal" Margin="10,10,0,0" DockPanel.Dock="Top">
+            <TextBlock 
+                Text="{DynamicResource LOC_PlayNext_PluginName}" 
+                Style="{StaticResource BaseTextBlockStyle}"
+                FontSize="18"
+                Margin="10,0,0,0"
+                VerticalAlignment="Center" />
+        </StackPanel>
+
+        <StackPanel Orientation="Horizontal" Margin="0,0,10,0" HorizontalAlignment="Right" DockPanel.Dock="Top">
             <Button
                 Margin="0,0,10,0"
                 Width="50"
@@ -78,163 +76,164 @@
             </Button>
         </StackPanel>
 
-        <Grid Grid.Row="2" Visibility="{Binding ActiveShowcaseType, Converter={converters:ShowcaseTypeToCollapsedVisibilityConverter}, ConverterParameter={x:Static model:ShowcaseType.List}}">
-            <ListView Grid.Row="0"
-                      ItemsSource="{Binding Games}"
-                      HorizontalContentAlignment="Stretch"
-                      VerticalContentAlignment="Stretch"
-                      Background="Transparent">
-                <ListView.View>
-                    <GridView>
-                        <GridViewColumn>
-                            <GridViewColumn.CellTemplate>
-                                <DataTemplate>
-                                    <Image Width="25" Source="{Binding Icon,
-                                            Converter={StaticResource UriToBitmapImageConverter},
-                                            ConverterParameter=25,
-                                            Mode=OneWay,
-                                            FallbackValue={StaticResource DefaultGameIcon},
-                                            TargetNullValue={StaticResource DefaultGameIcon}}">
+        <Grid>
+            <Grid Visibility="{Binding ActiveShowcaseType, Converter={converters:ShowcaseTypeToCollapsedVisibilityConverter}, ConverterParameter={x:Static model:ShowcaseType.List}}">
+                <ListView ItemsSource="{Binding Games}"
+                          HorizontalContentAlignment="Stretch"
+                          VerticalContentAlignment="Stretch"
+                          Background="Transparent">
+                    <ListView.View>
+                        <GridView>
+                            <GridViewColumn>
+                                <GridViewColumn.CellTemplate>
+                                    <DataTemplate>
+                                        <Image Width="25" Source="{Binding Icon,
+                                                Converter={StaticResource UriToBitmapImageConverter},
+                                                ConverterParameter=25,
+                                                Mode=OneWay,
+                                                FallbackValue={StaticResource DefaultGameIcon},
+                                                TargetNullValue={StaticResource DefaultGameIcon}}">
+                                        </Image>
+                                    </DataTemplate>
+                                </GridViewColumn.CellTemplate>
+                            </GridViewColumn>
+                            <GridViewColumn>
+                                <GridViewColumnHeader>
+                                    <TextBlock Text="{DynamicResource LOC_PlayNext_MainScoreColumn}" VerticalAlignment="Center" HorizontalAlignment="Center" />
+                                </GridViewColumnHeader>
+                                <GridViewColumn.CellTemplate>
+                                    <DataTemplate>
+                                        <TextBlock Text="{Binding Score, StringFormat=#0.00}" VerticalAlignment="Center" HorizontalAlignment="Center" />
+                                    </DataTemplate>
+                                </GridViewColumn.CellTemplate>
+                            </GridViewColumn>
+                            <GridViewColumn>
+                                <GridViewColumnHeader>
+                                    <TextBlock Text="{DynamicResource LOC_PlayNext_MainNameColumn}" VerticalAlignment="Center" />
+                                </GridViewColumnHeader>
+                                <GridViewColumn.CellTemplate>
+                                    <DataTemplate>
+                                        <TextBlock Text="{Binding Name}" VerticalAlignment="Center" />
+                                    </DataTemplate>
+                                </GridViewColumn.CellTemplate>
+                            </GridViewColumn>
+                            <GridViewColumn>
+                                <GridViewColumn.CellTemplate>
+                                    <DataTemplate>
+                                        <Button Command="{Binding OpenDetails}"  Content="{DynamicResource LOC_PlayNext_MainDetailsButton}"></Button>
+                                    </DataTemplate>
+                                </GridViewColumn.CellTemplate>
+                            </GridViewColumn>
+                        </GridView>
+                    </ListView.View>
+                </ListView>
+            </Grid>
+
+            <Grid Visibility="{Binding ActiveShowcaseType, Converter={converters:ShowcaseTypeToCollapsedVisibilityConverter}, ConverterParameter={x:Static model:ShowcaseType.Covers}}">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="*"></RowDefinition>
+                    <RowDefinition Height="Auto"></RowDefinition>
+                    <RowDefinition Height="*"></RowDefinition>
+                </Grid.RowDefinitions>
+
+                <ListBox Grid.Row="1"  ItemsSource="{Binding TopGames}" Background="Transparent">
+                    <ListBox.ItemContainerStyle>
+                        <Style TargetType="{x:Type ListBoxItem}" BasedOn="{StaticResource {x:Type ListBoxItem}}">
+                            <Setter Property="Focusable" Value="False" />
+                            <Setter Property="Template">
+                                <Setter.Value>
+                                    <ControlTemplate TargetType="{x:Type ListBoxItem}">
+                                        <Border x:Name="Bd" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" Padding="{TemplateBinding Padding}" SnapsToDevicePixels="true">
+                                            <ContentPresenter HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
+                                        </Border>
+                                        <ControlTemplate.Triggers>
+                                            <Trigger Property="IsSelected" Value="true">
+                                                <Setter Property="Background" TargetName="Bd" Value="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}" />
+                                                <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}" />
+                                            </Trigger>
+                                            <MultiTrigger>
+                                                <MultiTrigger.Conditions>
+                                                    <Condition Property="IsSelected" Value="true" />
+                                                    <Condition Property="Selector.IsSelectionActive" Value="false" />
+                                                </MultiTrigger.Conditions>
+                                                <Setter Property="Background" TargetName="Bd" Value="{DynamicResource {x:Static SystemColors.InactiveSelectionHighlightBrushKey}}" />
+                                                <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.InactiveSelectionHighlightTextBrushKey}}" />
+                                            </MultiTrigger>
+                                            <Trigger Property="IsEnabled" Value="false">
+                                                <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}" />
+                                            </Trigger>
+                                            <Trigger Property="IsMouseOver" Value="True">
+                                                <Setter Property="Background" Value="Transparent" />
+                                            </Trigger>
+                                        </ControlTemplate.Triggers>
+                                    </ControlTemplate>
+                                </Setter.Value>
+                            </Setter>
+                        </Style>
+                    </ListBox.ItemContainerStyle>
+                    <ListBox.ItemsPanel>
+                        <ItemsPanelTemplate>
+                            <VirtualizingStackPanel IsItemsHost="True" Orientation="Horizontal" MouseWheel="OnCoversListBoxMouseWheel" />
+                        </ItemsPanelTemplate>
+                    </ListBox.ItemsPanel>
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <Grid>
+                                <Grid.RenderTransform>
+                                    <ScaleTransform  x:Name="HoverTransform" CenterX="150" CenterY="200" ScaleX="1" ScaleY="1" />
+                                </Grid.RenderTransform>
+                                <Grid.Triggers>
+                                    <EventTrigger RoutedEvent="Grid.MouseEnter">
+
+                                        <EventTrigger.Actions>
+                                            <StopStoryboard BeginStoryboardName="hoverStopStoryboard"></StopStoryboard>
+                                            <BeginStoryboard Name="hoverStartStoryboard">
+                                                <Storyboard>
+                                                    <DoubleAnimation
+                                                        Storyboard.TargetName="HoverTransform"
+                                                        Storyboard.TargetProperty="ScaleX"
+                                                        From="1" To="1.05" Duration="0:0:0.1" />
+                                                    <DoubleAnimation
+                                                        Storyboard.TargetName="HoverTransform"
+                                                        Storyboard.TargetProperty="ScaleY"
+                                                        From="1" To="1.05" Duration="0:0:0.1" />
+                                                </Storyboard>
+                                            </BeginStoryboard>
+                                        </EventTrigger.Actions>
+                                    </EventTrigger>
+                                    <EventTrigger RoutedEvent="Grid.MouseLeave">
+                                        <EventTrigger.Actions>
+                                            <StopStoryboard BeginStoryboardName="hoverStartStoryboard"></StopStoryboard>
+                                            <BeginStoryboard Name="hoverStopStoryboard">
+                                                <Storyboard>
+                                                    <DoubleAnimation
+                                                        Storyboard.TargetName="HoverTransform"
+                                                        Storyboard.TargetProperty="ScaleX"
+                                                        From="1.05" To="1" Duration="0:0:0.05" />
+                                                    <DoubleAnimation
+                                                        Storyboard.TargetName="HoverTransform"
+                                                        Storyboard.TargetProperty="ScaleY"
+                                                        From="1.05" To="1" Duration="0:0:0.05" />
+                                                </Storyboard>
+                                            </BeginStoryboard>
+                                        </EventTrigger.Actions>
+                                    </EventTrigger>
+                                </Grid.Triggers>
+
+                                <Button Command="{Binding OpenDetails}" Background="Transparent">
+                                    <Image Height="400" Source="{Binding CoverImage,
+                                        Converter={StaticResource UriToBitmapImageConverter},
+                                        ConverterParameter=400,
+                                        Mode=OneWay,
+                                        FallbackValue={StaticResource DefaultGameCover},
+                                        TargetNullValue={StaticResource DefaultGameCover}}">
                                     </Image>
-                                </DataTemplate>
-                            </GridViewColumn.CellTemplate>
-                        </GridViewColumn>
-                        <GridViewColumn>
-                            <GridViewColumnHeader>
-                                <TextBlock Text="{DynamicResource LOC_PlayNext_MainScoreColumn}" VerticalAlignment="Center" HorizontalAlignment="Center" />
-                            </GridViewColumnHeader>
-                            <GridViewColumn.CellTemplate>
-                                <DataTemplate>
-                                    <TextBlock Text="{Binding Score, StringFormat=#0.00}" VerticalAlignment="Center" HorizontalAlignment="Center" />
-                                </DataTemplate>
-                            </GridViewColumn.CellTemplate>
-                        </GridViewColumn>
-                        <GridViewColumn>
-                            <GridViewColumnHeader>
-                                <TextBlock Text="{DynamicResource LOC_PlayNext_MainNameColumn}" VerticalAlignment="Center" />
-                            </GridViewColumnHeader>
-                            <GridViewColumn.CellTemplate>
-                                <DataTemplate>
-                                    <TextBlock Text="{Binding Name}" VerticalAlignment="Center" />
-                                </DataTemplate>
-                            </GridViewColumn.CellTemplate>
-                        </GridViewColumn>
-                        <GridViewColumn>
-                            <GridViewColumn.CellTemplate>
-                                <DataTemplate>
-                                    <Button Command="{Binding OpenDetails}"  Content="{DynamicResource LOC_PlayNext_MainDetailsButton}"></Button>
-                                </DataTemplate>
-                            </GridViewColumn.CellTemplate>
-                        </GridViewColumn>
-                    </GridView>
-                </ListView.View>
-            </ListView>
+                                </Button>
+                            </Grid>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ListBox>
+            </Grid>
         </Grid>
-
-        <Grid Grid.Row="2"  Visibility="{Binding ActiveShowcaseType, Converter={converters:ShowcaseTypeToCollapsedVisibilityConverter}, ConverterParameter={x:Static model:ShowcaseType.Covers}}">
-            <Grid.RowDefinitions>
-                <RowDefinition Height="*"></RowDefinition>
-                <RowDefinition Height="Auto"></RowDefinition>
-                <RowDefinition Height="*"></RowDefinition>
-            </Grid.RowDefinitions>
-
-            <ListBox Grid.Row="1"  ItemsSource="{Binding TopGames}" Background="Transparent">
-                <ListBox.ItemContainerStyle>
-                    <Style TargetType="{x:Type ListBoxItem}" BasedOn="{StaticResource {x:Type ListBoxItem}}">
-                        <Setter Property="Focusable" Value="False" />
-                        <Setter Property="Template">
-                            <Setter.Value>
-                                <ControlTemplate TargetType="{x:Type ListBoxItem}">
-                                    <Border x:Name="Bd" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" Padding="{TemplateBinding Padding}" SnapsToDevicePixels="true">
-                                        <ContentPresenter HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
-                                    </Border>
-                                    <ControlTemplate.Triggers>
-                                        <Trigger Property="IsSelected" Value="true">
-                                            <Setter Property="Background" TargetName="Bd" Value="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}" />
-                                            <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}" />
-                                        </Trigger>
-                                        <MultiTrigger>
-                                            <MultiTrigger.Conditions>
-                                                <Condition Property="IsSelected" Value="true" />
-                                                <Condition Property="Selector.IsSelectionActive" Value="false" />
-                                            </MultiTrigger.Conditions>
-                                            <Setter Property="Background" TargetName="Bd" Value="{DynamicResource {x:Static SystemColors.InactiveSelectionHighlightBrushKey}}" />
-                                            <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.InactiveSelectionHighlightTextBrushKey}}" />
-                                        </MultiTrigger>
-                                        <Trigger Property="IsEnabled" Value="false">
-                                            <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}" />
-                                        </Trigger>
-                                        <Trigger Property="IsMouseOver" Value="True">
-                                            <Setter Property="Background" Value="Transparent" />
-                                        </Trigger>
-                                    </ControlTemplate.Triggers>
-                                </ControlTemplate>
-                            </Setter.Value>
-                        </Setter>
-                    </Style>
-                </ListBox.ItemContainerStyle>
-                <ListBox.ItemsPanel>
-                    <ItemsPanelTemplate>
-                        <VirtualizingStackPanel IsItemsHost="True" Orientation="Horizontal" MouseWheel="OnCoversListBoxMouseWheel" />
-                    </ItemsPanelTemplate>
-                </ListBox.ItemsPanel>
-                <ItemsControl.ItemTemplate>
-                    <DataTemplate>
-                        <Grid>
-                            <Grid.RenderTransform>
-                                <ScaleTransform  x:Name="HoverTransform" CenterX="150" CenterY="200" ScaleX="1" ScaleY="1" />
-                            </Grid.RenderTransform>
-                            <Grid.Triggers>
-                                <EventTrigger RoutedEvent="Grid.MouseEnter">
-
-                                    <EventTrigger.Actions>
-                                        <StopStoryboard BeginStoryboardName="hoverStopStoryboard"></StopStoryboard>
-                                        <BeginStoryboard Name="hoverStartStoryboard">
-                                            <Storyboard>
-                                                <DoubleAnimation
-                                                    Storyboard.TargetName="HoverTransform"
-                                                    Storyboard.TargetProperty="ScaleX"
-                                                    From="1" To="1.05" Duration="0:0:0.1" />
-                                                <DoubleAnimation
-                                                    Storyboard.TargetName="HoverTransform"
-                                                    Storyboard.TargetProperty="ScaleY"
-                                                    From="1" To="1.05" Duration="0:0:0.1" />
-                                            </Storyboard>
-                                        </BeginStoryboard>
-                                    </EventTrigger.Actions>
-                                </EventTrigger>
-                                <EventTrigger RoutedEvent="Grid.MouseLeave">
-                                    <EventTrigger.Actions>
-                                        <StopStoryboard BeginStoryboardName="hoverStartStoryboard"></StopStoryboard>
-                                        <BeginStoryboard Name="hoverStopStoryboard">
-                                            <Storyboard>
-                                                <DoubleAnimation
-                                                    Storyboard.TargetName="HoverTransform"
-                                                    Storyboard.TargetProperty="ScaleX"
-                                                    From="1.05" To="1" Duration="0:0:0.05" />
-                                                <DoubleAnimation
-                                                    Storyboard.TargetName="HoverTransform"
-                                                    Storyboard.TargetProperty="ScaleY"
-                                                    From="1.05" To="1" Duration="0:0:0.05" />
-                                            </Storyboard>
-                                        </BeginStoryboard>
-                                    </EventTrigger.Actions>
-                                </EventTrigger>
-                            </Grid.Triggers>
-
-                            <Button Command="{Binding OpenDetails}" Background="Transparent">
-                                <Image Height="400" Source="{Binding CoverImage,
-                                    Converter={StaticResource UriToBitmapImageConverter},
-                                    ConverterParameter=400,
-                                    Mode=OneWay,
-                                    FallbackValue={StaticResource DefaultGameCover},
-                                    TargetNullValue={StaticResource DefaultGameCover}}">
-                                </Image>
-                            </Button>
-                        </Grid>
-                    </DataTemplate>
-                </ItemsControl.ItemTemplate>
-            </ListBox>
-        </Grid>
-    </Grid>
+    </DockPanel>
 </PluginUserControl>

--- a/PlayNext/Views/PlayNextMainView.xaml
+++ b/PlayNext/Views/PlayNextMainView.xaml
@@ -97,7 +97,8 @@
                 <ListView ItemsSource="{Binding Games}"
                           HorizontalContentAlignment="Stretch"
                           VerticalContentAlignment="Stretch"
-                          Background="Transparent">
+                          Background="Transparent"
+                          BorderThickness="0">
                     <ListView.View>
                         <GridView>
                             <GridViewColumn>
@@ -152,7 +153,7 @@
                     <RowDefinition Height="*"></RowDefinition>
                 </Grid.RowDefinitions>
 
-                <ListBox Grid.Row="1"  ItemsSource="{Binding TopGames}" Background="Transparent">
+                <ListBox Grid.Row="1"  ItemsSource="{Binding TopGames}" Background="Transparent" BorderThickness="0">
                     <ListBox.ItemContainerStyle>
                         <Style TargetType="{x:Type ListBoxItem}" BasedOn="{StaticResource {x:Type ListBoxItem}}">
                             <Setter Property="Focusable" Value="False" />
@@ -236,7 +237,7 @@
                                     </EventTrigger>
                                 </Grid.Triggers>
 
-                                <Button Command="{Binding OpenDetails}" Background="Transparent">
+                                <Button Command="{Binding OpenDetails}" Background="Transparent" BorderThickness="0">
                                     <Image Height="400" Source="{Binding CoverImage,
                                         Converter={StaticResource UriToBitmapImageConverter},
                                         ConverterParameter=400,

--- a/PlayNext/Views/PlayNextMainView.xaml
+++ b/PlayNext/Views/PlayNextMainView.xaml
@@ -40,49 +40,56 @@
     </PluginUserControl.Resources>
 
     <DockPanel>
-        <StackPanel Orientation="Horizontal" Margin="10,10,0,0" DockPanel.Dock="Top">
-            <TextBlock VerticalAlignment="Center" WindowChrome.IsHitTestVisibleInChrome="True">
-                <Hyperlink Command="{Binding NavigateBackCommand}">
-                    <TextBlock 
-                        Text="&#xea5c;" 
-                        FontFamily="{DynamicResource FontIcoFont}"
-                        FontSize="26" 
-                        Style="{x:Null}" />
-                </Hyperlink>
-            </TextBlock>
-            <TextBlock 
-                Text="{DynamicResource LOC_PlayNext_PluginName}" 
-                Style="{StaticResource BaseTextBlockStyle}"
-                FontSize="18"
-                Margin="10,0,0,0"
-                VerticalAlignment="Center" />
-        </StackPanel>
+        <StackPanel Orientation="Horizontal" Margin="10,10,10,10" DockPanel.Dock="Top">
 
-        <StackPanel Orientation="Horizontal" Margin="0,0,10,0" HorizontalAlignment="Right" DockPanel.Dock="Top">
-            <Button
-                Margin="0,0,10,0"
+            <StackPanel Orientation="Horizontal" Margin="0,0,20,0">
+                <TextBlock VerticalAlignment="Center" WindowChrome.IsHitTestVisibleInChrome="True">
+                    <Hyperlink Command="{Binding NavigateBackCommand}">
+                        <TextBlock 
+                            Text="&#xea5c;" 
+                            FontFamily="{DynamicResource FontIcoFont}"
+                            FontSize="26" 
+                            Style="{x:Null}" />
+                    </Hyperlink>
+                </TextBlock>
+                <TextBlock 
+                    Text="{DynamicResource LOC_PlayNext_PluginName}" 
+                    Style="{StaticResource BaseTextBlockStyle}"
+                    FontSize="18"
+                    Margin="10,0,0,0"
+                    VerticalAlignment="Center" />
+            </StackPanel>
+
+            
+            <Button Margin="0,0,10,0"
                 Width="50"
                 Height="30"
+                WindowChrome.IsHitTestVisibleInChrome="True"
                 Command="{Binding Refresh}"
                 Visibility="{Binding IsRefreshAvailable, Converter={converters:BooleanToCollapsedVisibilityConverter}}">
                 <TextBlock FontFamily="{DynamicResource FontIcoFont}" Text="&#xefd1;"></TextBlock>
             </Button>
-            <Button
-                Margin="0,0,10,0"
-                Width="50"
-                Height="30"
-                Command="{Binding SwitchToCovers}"
-                IsEnabled="{Binding ActiveShowcaseType, Converter={converters:ShowcaseTypeToInvertedBooleanConverter}, ConverterParameter={x:Static model:ShowcaseType.Covers}}">
-                ▋ ▋
-            </Button>
-            <Button
-                Margin="0,0,50,0"
-                Width="50"
-                Height="30"
-                Command="{Binding SwitchToList}"
-                IsEnabled="{Binding ActiveShowcaseType, Converter={converters:ShowcaseTypeToInvertedBooleanConverter}, ConverterParameter={x:Static model:ShowcaseType.List}}">
-                ≡
-            </Button>
+
+            <StackPanel Orientation="Horizontal" Margin="10,0,20,0">
+                <Button
+                    Margin="0,0,10,0"
+                    Width="50"
+                    Height="30"
+                    WindowChrome.IsHitTestVisibleInChrome="True"
+                    Command="{Binding SwitchToCovers}"
+                    IsEnabled="{Binding ActiveShowcaseType, Converter={converters:ShowcaseTypeToInvertedBooleanConverter}, ConverterParameter={x:Static model:ShowcaseType.Covers}}">
+                    ▋ ▋
+                </Button>
+                <Button
+                    Width="50"
+                    Height="30"
+                    WindowChrome.IsHitTestVisibleInChrome="True"
+                    Command="{Binding SwitchToList}"
+                    IsEnabled="{Binding ActiveShowcaseType, Converter={converters:ShowcaseTypeToInvertedBooleanConverter}, ConverterParameter={x:Static model:ShowcaseType.List}}">
+                    ≡
+                </Button>
+            </StackPanel>
+ 
         </StackPanel>
 
         <Grid>

--- a/PlayNext/Views/PlayNextMainView.xaml
+++ b/PlayNext/Views/PlayNextMainView.xaml
@@ -71,23 +71,23 @@
             </Button>
 
             <StackPanel Orientation="Horizontal" Margin="10,0,20,0">
-                <Button
+                <ToggleButton
                     Margin="0,0,10,0"
                     Width="50"
                     Height="30"
                     WindowChrome.IsHitTestVisibleInChrome="True"
                     Command="{Binding SwitchToCovers}"
-                    IsEnabled="{Binding ActiveShowcaseType, Converter={converters:ShowcaseTypeToInvertedBooleanConverter}, ConverterParameter={x:Static model:ShowcaseType.Covers}}">
+                    IsChecked="{Binding ActiveShowcaseType, Mode=OneWay, Converter={converters:ShowcaseTypeToBooleanConverter}, ConverterParameter={x:Static model:ShowcaseType.Covers}}">
                     ▋ ▋
-                </Button>
-                <Button
+                </ToggleButton>
+                <ToggleButton
                     Width="50"
                     Height="30"
                     WindowChrome.IsHitTestVisibleInChrome="True"
                     Command="{Binding SwitchToList}"
-                    IsEnabled="{Binding ActiveShowcaseType, Converter={converters:ShowcaseTypeToInvertedBooleanConverter}, ConverterParameter={x:Static model:ShowcaseType.List}}">
+                    IsChecked="{Binding ActiveShowcaseType, Mode=OneWay, Converter={converters:ShowcaseTypeToBooleanConverter}, ConverterParameter={x:Static model:ShowcaseType.List}}">
                     ≡
-                </Button>
+                </ToggleButton>
             </StackPanel>
  
         </StackPanel>

--- a/PlayNext/Views/PlayNextMainView.xaml
+++ b/PlayNext/Views/PlayNextMainView.xaml
@@ -45,7 +45,12 @@
             <RowDefinition Height="50px"></RowDefinition>
             <RowDefinition Height="*"></RowDefinition>
         </Grid.RowDefinitions>
-        <TextBlock Grid.Row="0" Text="{DynamicResource LOC_PlayNext_PluginName}" Margin="10,30,0,0"></TextBlock>
+        <TextBlock Grid.Row="0" 
+                   Text="{DynamicResource LOC_PlayNext_PluginName}" 
+                   Style="{StaticResource BaseTextBlockStyle}"
+                   FontSize="18"
+                   Margin="10,30,0,0"
+                   VerticalAlignment="Center"></TextBlock>
         <StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Right">
             <Button
                 Margin="0,0,10,0"

--- a/PlayNext/Views/PlayNextMainView.xaml
+++ b/PlayNext/Views/PlayNextMainView.xaml
@@ -41,6 +41,15 @@
 
     <DockPanel>
         <StackPanel Orientation="Horizontal" Margin="10,10,0,0" DockPanel.Dock="Top">
+            <TextBlock VerticalAlignment="Center" WindowChrome.IsHitTestVisibleInChrome="True">
+                <Hyperlink Command="{Binding NavigateBackCommand}">
+                    <TextBlock 
+                        Text="&#xea5c;" 
+                        FontFamily="{DynamicResource FontIcoFont}"
+                        FontSize="26" 
+                        Style="{x:Null}" />
+                </Hyperlink>
+            </TextBlock>
             <TextBlock 
                 Text="{DynamicResource LOC_PlayNext_PluginName}" 
                 Style="{StaticResource BaseTextBlockStyle}"

--- a/PlayNext/Views/PlayNextMainView.xaml
+++ b/PlayNext/Views/PlayNextMainView.xaml
@@ -40,9 +40,11 @@
     </PluginUserControl.Resources>
 
     <DockPanel>
+        <!--Header-->
         <StackPanel Orientation="Horizontal" Margin="10,10,10,10" DockPanel.Dock="Top">
-
+            
             <StackPanel Orientation="Horizontal" Margin="0,0,20,0">
+                <!--Back Button-->
                 <TextBlock VerticalAlignment="Center" WindowChrome.IsHitTestVisibleInChrome="True">
                     <Hyperlink Command="{Binding NavigateBackCommand}">
                         <TextBlock 
@@ -52,6 +54,8 @@
                             Style="{x:Null}" />
                     </Hyperlink>
                 </TextBlock>
+
+                <!--Plugin Name Title-->
                 <TextBlock 
                     Text="{DynamicResource LOC_PlayNext_PluginName}" 
                     Style="{StaticResource BaseTextBlockStyle}"
@@ -60,7 +64,7 @@
                     VerticalAlignment="Center" />
             </StackPanel>
 
-            
+            <!--Refresh Button-->
             <Button Margin="0,0,10,0"
                 Width="50"
                 Height="30"
@@ -70,6 +74,7 @@
                 <TextBlock FontFamily="{DynamicResource FontIcoFont}" Text="&#xefd1;"></TextBlock>
             </Button>
 
+            <!--Showcase Type Toggle Buttons-->
             <StackPanel Orientation="Horizontal" Margin="10,0,20,0">
                 <ToggleButton
                     Margin="0,0,10,0"
@@ -92,7 +97,9 @@
  
         </StackPanel>
 
+        <!--Content-->
         <Grid>
+            <!--List Showcase Type-->
             <Grid Visibility="{Binding ActiveShowcaseType, Converter={converters:ShowcaseTypeToCollapsedVisibilityConverter}, ConverterParameter={x:Static model:ShowcaseType.List}}">
                 <ListView ItemsSource="{Binding Games}"
                           HorizontalContentAlignment="Stretch"
@@ -146,6 +153,7 @@
                 </ListView>
             </Grid>
 
+            <!--Covers Showcase Type-->
             <Grid Visibility="{Binding ActiveShowcaseType, Converter={converters:ShowcaseTypeToCollapsedVisibilityConverter}, ConverterParameter={x:Static model:ShowcaseType.Covers}}">
                 <Grid.RowDefinitions>
                     <RowDefinition Height="*"></RowDefinition>


### PR DESCRIPTION
## Summary
Changed the main view UI to be more inline with default playnite views and to clean it up.

- Changed plugin title text to match title of Statistics tab, including adding the back button.
- Moved showcase type buttons (in a group) and refresh button to the header.
- Changed showcase type buttons to toggle buttons to match how the library view buttons work.
- Removed borders around certain elements to clean up the visuals.

## UI
### Before
<img width="2879" height="1497" alt="image" src="https://github.com/user-attachments/assets/f2fe1b5a-41eb-4832-8aff-587a5bad5957" />
<img width="2879" height="1049" alt="image" src="https://github.com/user-attachments/assets/c64e77e5-82fe-4852-9131-cc6609af0489" />

### After
<img width="2879" height="1454" alt="image" src="https://github.com/user-attachments/assets/06ca0924-16a8-488f-a9b2-7774ad289e6b" />
<img width="2879" height="1051" alt="image" src="https://github.com/user-attachments/assets/488244d8-bf37-4b05-82a1-5d61f9bb8633" />

