### PR TITLE
feat: add exclude game button

### DIFF
--- a/PlayNext.UnitTests/Model/Filters/ExclusionListFilterTests.cs
+++ b/PlayNext.UnitTests/Model/Filters/ExclusionListFilterTests.cs
@@ -139,5 +139,24 @@ namespace PlayNext.UnitTests.Model.Filters
 			// Assert
 			Assert.Equal(games.Count, result.Count);
 		}
+
+		[Theory]
+		[AutoData]
+		public void Filter_ExcludesGame_ThatHasExcludedGameId(
+			List<Game> games,
+			PlayNextSettings settings,
+			ExclusionListFilter sut)
+		{
+			// Arrange
+			var filteredOutGame = games.Last();
+			settings.ExcludedGameIds.Add(filteredOutGame.Id);
+
+			// Act
+			var result = sut.Filter(games, settings);
+
+			// Assert
+			Assert.Equal(games.Count - 1, result.Count);
+			Assert.DoesNotContain(result, x => x.Id == filteredOutGame.Id);
+		}
 	}
 }

--- a/PlayNext.UnitTests/PlayNext.UnitTests.csproj
+++ b/PlayNext.UnitTests/PlayNext.UnitTests.csproj
@@ -100,6 +100,7 @@
     <Compile Include="Settings\Old\SettingsV2Tests.cs" />
     <Compile Include="Settings\Old\SettingsV1Tests.cs" />
     <Compile Include="Settings\Old\SettingsV3Tests.cs" />
+    <Compile Include="Settings\Old\SettingsV4Tests.cs" />
     <Compile Include="Settings\Preset\SettingsPresetTests.cs" />
     <Compile Include="Settings\SettingsMigratorTests.cs" />
     <Compile Include="Settings\StartupSettingsValidatorTests.cs" />

--- a/PlayNext.UnitTests/Settings/Old/SettingsV4Tests.cs
+++ b/PlayNext.UnitTests/Settings/Old/SettingsV4Tests.cs
@@ -1,36 +1,33 @@
-﻿using AutoFixture.Xunit2;
+using AutoFixture.Xunit2;
 using PlayNext.Settings;
 using PlayNext.Settings.Old;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace PlayNext.UnitTests.Settings.Old
 {
-	public class SettingsV3Tests
+	public class SettingsV4Tests
 	{
 		[Theory, AutoData]
-		public void Migrate_MigratesToV4(
-			SettingsV3 oldSettings)
+		public void Migrate_MigratesToV5(
+			SettingsV4 oldSettings)
 		{
 			// Act
-			var result = oldSettings.Migrate() as SettingsV4;
+			var result = oldSettings.Migrate() as PlayNextSettings;
 
 			// Assert
 			Assert.NotNull(result);
 			Assert.Equal(oldSettings.SelectedPresetId, result.SelectedPresetId);
+			Assert.Equal(oldSettings.ShowSidebarItem, result.ShowSidebarItem);
 			Assert.Equal(oldSettings.RecentDays, result.RecentDays);
 			Assert.Equal(oldSettings.NumberOfTopGames, result.NumberOfTopGames);
+			Assert.Equal(oldSettings.AverageUserScore, result.AverageUserScore);
 			Assert.Equal(oldSettings.RefreshOnGameUpdates, result.RefreshOnGameUpdates);
 
 			Assert.Equal(oldSettings.TotalPlaytimeWeight, result.TotalPlaytimeWeight);
 			Assert.Equal(oldSettings.RecentPlaytimeWeight, result.RecentPlaytimeWeight);
 			Assert.Equal(oldSettings.RecentOrderWeight, result.RecentOrderWeight);
-			Assert.Equal(0, result.UserFavouritesWeight);
-			Assert.Equal(0, result.UserScoreWeight);
+			Assert.Equal(oldSettings.UserFavouritesWeight, result.UserFavouritesWeight);
+			Assert.Equal(oldSettings.UserScoreWeight, result.UserScoreWeight);
 
 			Assert.Equal(oldSettings.GenreWeight, result.GenreWeight);
 			Assert.Equal(oldSettings.FeatureWeight, result.FeatureWeight);
@@ -46,6 +43,7 @@ namespace PlayNext.UnitTests.Settings.Old
 			Assert.Equal(oldSettings.GameLengthHours, result.GameLengthHours);
 			Assert.Equal(oldSettings.SeriesWeight, result.SeriesWeight);
 			Assert.Equal(oldSettings.OrderSeriesBy, result.OrderSeriesBy);
+			Assert.Equal(oldSettings.RandomWeight, result.RandomWeight);
 
 			Assert.Equal(oldSettings.UnplayedGameDefinition, result.UnplayedGameDefinition);
 			Assert.Equal(oldSettings.UnplayedCompletionStatuses, result.UnplayedCompletionStatuses);
@@ -59,7 +57,7 @@ namespace PlayNext.UnitTests.Settings.Old
 			Assert.Equal(oldSettings.StartPageLabelIsHorizontal, result.StartPageLabelIsHorizontal);
 			Assert.Equal(oldSettings.StartPageMinCoverCount, result.StartPageMinCoverCount);
 
-			Assert.Equal(4, result.Version);
+			Assert.Equal(5, result.Version);
 		}
 	}
 }

--- a/PlayNext/Infrastructure/Converters/ShowcaseTypeToBooleanConverter.cs
+++ b/PlayNext/Infrastructure/Converters/ShowcaseTypeToBooleanConverter.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Globalization;
+using System.Windows.Data;
+using PlayNext.Model.Data;
+
+namespace PlayNext.Infrastructure.Converters
+{
+    internal class ShowcaseTypeToBooleanConverter : BaseConverter, IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is ShowcaseType selectedType &&
+                parameter is ShowcaseType showcaseType)
+            {
+                return selectedType == showcaseType;
+            }
+
+            return false;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/PlayNext/Localization/en_US.xaml
+++ b/PlayNext/Localization/en_US.xaml
@@ -66,6 +66,7 @@
     <sys:String x:Key="LOC_PlayNext_SettingsPlatformsHeader">Platforms</sys:String>
     <sys:String x:Key="LOC_PlayNext_SettingsCategoriesHeader">Categories</sys:String>
     <sys:String x:Key="LOC_PlayNext_SettingsTagsHeader">Tags</sys:String>
+    <sys:String x:Key="LOC_PlayNext_SettingsGamesHeader">Games</sys:String>
     <sys:String x:Key="LOC_PlayNext_SettingsAllowed">Allowed</sys:String>
     <sys:String x:Key="LOC_PlayNext_SettingsExcluded">Excluded</sys:String>
     <sys:String x:Key="LOC_PlayNext_SettingsFilter">Filter</sys:String>

--- a/PlayNext/Model/Filters/ExclusionListFilter.cs
+++ b/PlayNext/Model/Filters/ExclusionListFilter.cs
@@ -1,4 +1,4 @@
-﻿using PlayNext.Settings;
+using PlayNext.Settings;
 using Playnite.SDK.Models;
 using System.Collections.Generic;
 using System.Linq;
@@ -10,6 +10,7 @@ namespace PlayNext.Model.Filters
 		public IReadOnlyCollection<Game> Filter(IEnumerable<Game> games, PlayNextSettings settings)
 		{
 			return games
+				.Where(x => !settings.ExcludedGameIds.Contains(x.Id))
 				.Where(x => !settings.ExcludedSourceIds.Contains(x.SourceId))
 				.Where(x => x.PlatformIds == null || settings.ExcludedPlatformIds.All(e => !x.PlatformIds.Contains(e)))
 				.Where(x => x.CategoryIds == null || settings.ExcludedCategoryIds.All(e => !x.CategoryIds.Contains(e)))

--- a/PlayNext/PlayNext.cs
+++ b/PlayNext/PlayNext.cs
@@ -258,6 +258,25 @@ namespace PlayNext
 		{
 		}
 
+		public void ExcludeGame(Guid gameId)
+		{
+			var settings = LoadPluginSettings<PlayNextSettings>() ?? PlayNextSettings.Default;
+			if (!settings.ExcludedGameIds.Add(gameId))
+			{
+				return;
+			}
+
+			SavePluginSettings(settings);
+
+			if (_settings?.Settings != null)
+			{
+				_settings.Settings.ExcludedGameIds.Add(gameId);
+				_settings.Games.Settings = _settings.Settings;
+			}
+
+			OnPlayNextSettingsSaved();
+		}
+
 		public void OnPlayNextSettingsSaved()
 		{
 			var activeSettings = LoadPluginSettings<PlayNextSettings>();

--- a/PlayNext/PlayNext.csproj
+++ b/PlayNext/PlayNext.csproj
@@ -85,6 +85,7 @@
     <Compile Include="Settings\Old\SettingsV3.cs" />
     <Compile Include="Settings\Old\SettingsV2.cs" />
     <Compile Include="Settings\Old\SettingsV1.cs" />
+    <Compile Include="Settings\Old\SettingsV4.cs" />
     <Compile Include="Settings\Presets\SettingsPreset.cs" />
     <Compile Include="Settings\Presets\SettingsPresetManager.cs" />
     <Compile Include="ViewModels\CompletionStatusItem.cs" />

--- a/PlayNext/PlayNext.csproj
+++ b/PlayNext/PlayNext.csproj
@@ -61,6 +61,7 @@
     <Compile Include="Infrastructure\Converters\BaseConverter.cs" />
     <Compile Include="Infrastructure\Converters\BooleanToCollapsedVisibilityConverter.cs" />
     <Compile Include="Infrastructure\Converters\InvertedBooleanToCollapsedVisibilityConverter.cs" />
+    <Compile Include="Infrastructure\Converters\ShowcaseTypeToBooleanConverter.cs" />
     <Compile Include="Infrastructure\Converters\ShowcaseTypeToCollapsedVisibilityConverter.cs" />
     <Compile Include="Infrastructure\Converters\ShowcaseTypeToInvertedBooleanConverter.cs" />
     <Compile Include="Infrastructure\Converters\UriToBitmapImageConverter.cs" />

--- a/PlayNext/Settings/Old/SettingsV4.cs
+++ b/PlayNext/Settings/Old/SettingsV4.cs
@@ -1,19 +1,19 @@
-﻿using System;
-using System.Collections.Generic;
 using PlayNext.Model.Data;
+using System;
+using System.Collections.Generic;
 
 namespace PlayNext.Settings.Old
 {
-	public class SettingsV3 : ObservableObject, IMigratableSettings
+	public class SettingsV4 : ObservableObject, IMigratableSettings
 	{
 		public const int MaxWeightValue = 100;
 
-		public SettingsV3()
+		public SettingsV4()
 		{
-			Version = 3;
+			Version = 4;
 		}
 
-		private SettingsV3(AttributeCalculationWeights attributeCalculationWeights, GameScoreWeights gameScoreWeights) : this()
+		private SettingsV4(AttributeCalculationWeights attributeCalculationWeights, GameScoreWeights gameScoreWeights) : this()
 		{
 			SetAttributeWeights(attributeCalculationWeights);
 			SetGameWeights(gameScoreWeights);
@@ -23,8 +23,10 @@ namespace PlayNext.Settings.Old
 
 			GameLengthHours = 0;
 
+			ShowSidebarItem = true;
 			NumberOfTopGames = 30;
 			RecentDays = 14;
+			AverageUserScore = 70;
 			UnplayedGameDefinition = UnplayedGameDefinition.ZeroPlaytime;
 			UnplayedCompletionStatuses = Array.Empty<Guid>();
 			RefreshOnGameUpdates = false;
@@ -34,15 +36,21 @@ namespace PlayNext.Settings.Old
 			StartPageMinCoverCount = 1;
 		}
 
-		public static SettingsV3 Default => new SettingsV3(AttributeCalculationWeights.Default, GameScoreWeights.Default);
+		public static SettingsV4 Default => new SettingsV4(AttributeCalculationWeights.Default, GameScoreWeights.Default);
 
 		public Guid? SelectedPresetId { get; set; }
+
+		public bool ShowSidebarItem { get; set; }
 
 		public float TotalPlaytimeWeight { get; set; }
 
 		public float RecentPlaytimeWeight { get; set; }
 
 		public float RecentOrderWeight { get; set; }
+
+		public float UserFavouritesWeight { get; set; }
+
+		public float UserScoreWeight { get; set; }
 
 		public float GenreWeight { get; set; }
 
@@ -72,9 +80,13 @@ namespace PlayNext.Settings.Old
 
 		public int GameLengthHours { get; set; }
 
+		public float RandomWeight { get; set; }
+
 		public int NumberOfTopGames { get; set; }
 
 		public int RecentDays { get; set; }
+
+		public int AverageUserScore { get; set; }
 
 		public UnplayedGameDefinition UnplayedGameDefinition { get; set; }
 
@@ -100,15 +112,16 @@ namespace PlayNext.Settings.Old
 
 		public IVersionedSettings Migrate()
 		{
-			var settings = SettingsV4.Default;
+			var settings = PlayNextSettings.Default;
 
 			settings.SelectedPresetId = SelectedPresetId;
+			settings.ShowSidebarItem = ShowSidebarItem;
 
 			settings.TotalPlaytimeWeight = TotalPlaytimeWeight;
 			settings.RecentPlaytimeWeight = RecentPlaytimeWeight;
 			settings.RecentOrderWeight = RecentOrderWeight;
-			settings.UserFavouritesWeight = 0;
-			settings.UserScoreWeight = 0;
+			settings.UserFavouritesWeight = UserFavouritesWeight;
+			settings.UserScoreWeight = UserScoreWeight;
 
 			settings.GenreWeight = GenreWeight;
 			settings.FeatureWeight = FeatureWeight;
@@ -124,9 +137,11 @@ namespace PlayNext.Settings.Old
 			settings.GameLengthHours = GameLengthHours;
 			settings.SeriesWeight = SeriesWeight;
 			settings.OrderSeriesBy = OrderSeriesBy;
+			settings.RandomWeight = RandomWeight;
 
 			settings.RecentDays = RecentDays;
 			settings.NumberOfTopGames = NumberOfTopGames;
+			settings.AverageUserScore = AverageUserScore;
 			settings.RefreshOnGameUpdates = RefreshOnGameUpdates;
 
 			settings.UnplayedGameDefinition = UnplayedGameDefinition;
@@ -149,6 +164,8 @@ namespace PlayNext.Settings.Old
 			TotalPlaytimeWeight = attributeCalculationWeights.TotalPlaytime * MaxWeightValue;
 			RecentPlaytimeWeight = attributeCalculationWeights.RecentPlaytime * MaxWeightValue;
 			RecentOrderWeight = attributeCalculationWeights.RecentOrder * MaxWeightValue;
+			UserFavouritesWeight = attributeCalculationWeights.UserFavourites * MaxWeightValue;
+			UserScoreWeight = attributeCalculationWeights.UserScore * MaxWeightValue;
 		}
 
 		public void SetGameWeights(GameScoreWeights gameScoreWeights)
@@ -163,6 +180,7 @@ namespace PlayNext.Settings.Old
 			CommunityScoreWeight = gameScoreWeights.CommunityScore * MaxWeightValue;
 			ReleaseYearWeight = gameScoreWeights.ReleaseYear * MaxWeightValue;
 			GameLengthWeight = gameScoreWeights.GameLength * MaxWeightValue;
+			RandomWeight = gameScoreWeights.Random * MaxWeightValue;
 		}
 	}
 }

--- a/PlayNext/Settings/Old/SettingsVersions.md
+++ b/PlayNext/Settings/Old/SettingsVersions.md
@@ -15,3 +15,5 @@ V4
 - UserFavouritesWeight
 - UserScoreWeight
 - AverageUserScore
+
+V5

--- a/PlayNext/Settings/Old/SettingsVersions.md
+++ b/PlayNext/Settings/Old/SettingsVersions.md
@@ -17,3 +17,4 @@ V4
 - AverageUserScore
 
 V5
+- ExcludedGameIds

--- a/PlayNext/Settings/PlayNextSettings.cs
+++ b/PlayNext/Settings/PlayNextSettings.cs
@@ -9,7 +9,7 @@ namespace PlayNext.Settings
 	{
 		public const int MaxWeightValue = 100;
 		public const int MinWeightValue = 0;
-		public const int CurrentVersion = 4;
+		public const int CurrentVersion = 5;
 
 		private OrderSeriesBy _orderSeriesByChoice;
 		private int _desiredReleaseYear;

--- a/PlayNext/Settings/PlayNextSettings.cs
+++ b/PlayNext/Settings/PlayNextSettings.cs
@@ -224,6 +224,8 @@ namespace PlayNext.Settings
 
 		public HashSet<Guid> ExcludedTagIds { get; set; } = new HashSet<Guid>();
 
+		public HashSet<Guid> ExcludedGameIds { get; set; } = new HashSet<Guid>();
+
 		public bool StartPageShowLabel
 		{
 			get => _startPageShowLabel;

--- a/PlayNext/Settings/Presets/SettingsPresetManager.cs
+++ b/PlayNext/Settings/Presets/SettingsPresetManager.cs
@@ -119,6 +119,11 @@ namespace PlayNext.Settings.Presets
 					oldSettings = oldPresetV3.Settings;
 					break;
 
+				case 4:
+					var oldPresetV4 = ReadPreset<SettingsV4>(Path.Combine(_presetPath, $"{preset.Id}.json"));
+					oldSettings = oldPresetV4.Settings;
+					break;
+
 				default:
 					throw new NotImplementedException($"No implementation for preset v{preset.Settings.Version} migration");
 			}

--- a/PlayNext/Settings/SettingsMigrator.cs
+++ b/PlayNext/Settings/SettingsMigrator.cs
@@ -33,6 +33,10 @@ namespace PlayNext.Settings
 					versionedSettings = _pluginSettingsPersistence.LoadPluginSettings<SettingsV3>();
 					break;
 
+				case 4:
+					versionedSettings = _pluginSettingsPersistence.LoadPluginSettings<SettingsV4>();
+					break;
+
 				default:
 					throw new ArgumentException($"Version v{version} not configured in the migrator");
 			}

--- a/PlayNext/ViewModels/GameToPlayViewModel.cs
+++ b/PlayNext/ViewModels/GameToPlayViewModel.cs
@@ -39,6 +39,12 @@ namespace PlayNext.ViewModels
 				_plugin.PlayniteApi.MainView.SwitchToLibraryView();
 			});
 
+		public ICommand ExcludeGame =>
+			new RelayCommand(() =>
+			{
+				_plugin.ExcludeGame(Id);
+			});
+
 		public ICommand RunGame =>
 			new RelayCommand(() =>
 			{

--- a/PlayNext/ViewModels/PlayNextMainViewModel.cs
+++ b/PlayNext/ViewModels/PlayNextMainViewModel.cs
@@ -60,7 +60,9 @@ namespace PlayNext.ViewModels
 		// ReSharper disable once UnusedMember.Global
 		public ICommand SwitchToList => new RelayCommand(() => { ActiveShowcaseType = ShowcaseType.List; });
 
-		public void LoadData(ICollection<GameToPlayViewModel> games, PlayNextSettings settings)
+        public ICommand NavigateBackCommand => new RelayCommand(() => { API.Instance.MainView.SwitchToLibraryView(); });
+
+        public void LoadData(ICollection<GameToPlayViewModel> games, PlayNextSettings settings)
 		{
 			new Task(() =>
 			{

--- a/PlayNext/ViewModels/PlayNextSettingsViewModel.cs
+++ b/PlayNext/ViewModels/PlayNextSettingsViewModel.cs
@@ -45,6 +45,9 @@ namespace PlayNext.ViewModels
 			Tags = new ExclusionList<Tag>(
 				() => _plugin.PlayniteApi.Database.Tags.ToList(),
 				s => s.ExcludedTagIds);
+			Games = new ExclusionList<Game>(
+				() => _plugin.PlayniteApi.Database.Games.ToList(),
+				s => s.ExcludedGameIds);
 
 			var savedSettings = plugin.LoadPluginSettings<PlayNextSettings>();
 			Settings = savedSettings ?? PlayNextSettings.Default;
@@ -66,6 +69,7 @@ namespace PlayNext.ViewModels
 				Platforms.Settings = value;
 				Categories.Settings = value;
 				Tags.Settings = value;
+				Games.Settings = value;
 				OnPropertyChanged(string.Empty);
 			}
 		}
@@ -414,6 +418,8 @@ namespace PlayNext.ViewModels
 		public ExclusionList<Category> Categories { get; }
 
 		public ExclusionList<Tag> Tags { get; }
+
+		public ExclusionList<Game> Games { get; }
 
 		public void BeginEdit()
 		{

--- a/PlayNext/Views/PlayNextMainView.xaml
+++ b/PlayNext/Views/PlayNextMainView.xaml
@@ -39,19 +39,17 @@
         </ResourceDictionary>
     </PluginUserControl.Resources>
 
-    <Grid>
-        <Grid.RowDefinitions>
-            <RowDefinition Height="50px"></RowDefinition>
-            <RowDefinition Height="50px"></RowDefinition>
-            <RowDefinition Height="*"></RowDefinition>
-        </Grid.RowDefinitions>
-        <TextBlock Grid.Row="0" 
-                   Text="{DynamicResource LOC_PlayNext_PluginName}" 
-                   Style="{StaticResource BaseTextBlockStyle}"
-                   FontSize="18"
-                   Margin="10,30,0,0"
-                   VerticalAlignment="Center"></TextBlock>
-        <StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Right">
+    <DockPanel>
+        <StackPanel Orientation="Horizontal" Margin="10,10,0,0" DockPanel.Dock="Top">
+            <TextBlock 
+                Text="{DynamicResource LOC_PlayNext_PluginName}" 
+                Style="{StaticResource BaseTextBlockStyle}"
+                FontSize="18"
+                Margin="10,0,0,0"
+                VerticalAlignment="Center" />
+        </StackPanel>
+
+        <StackPanel Orientation="Horizontal" Margin="0,0,10,0" HorizontalAlignment="Right" DockPanel.Dock="Top">
             <Button
                 Margin="0,0,10,0"
                 Width="50"
@@ -78,163 +76,164 @@
             </Button>
         </StackPanel>
 
-        <Grid Grid.Row="2" Visibility="{Binding ActiveShowcaseType, Converter={converters:ShowcaseTypeToCollapsedVisibilityConverter}, ConverterParameter={x:Static model:ShowcaseType.List}}">
-            <ListView Grid.Row="0"
-                      ItemsSource="{Binding Games}"
-                      HorizontalContentAlignment="Stretch"
-                      VerticalContentAlignment="Stretch"
-                      Background="Transparent">
-                <ListView.View>
-                    <GridView>
-                        <GridViewColumn>
-                            <GridViewColumn.CellTemplate>
-                                <DataTemplate>
-                                    <Image Width="25" Source="{Binding Icon,
-                                            Converter={StaticResource UriToBitmapImageConverter},
-                                            ConverterParameter=25,
-                                            Mode=OneWay,
-                                            FallbackValue={StaticResource DefaultGameIcon},
-                                            TargetNullValue={StaticResource DefaultGameIcon}}">
+        <Grid>
+            <Grid Visibility="{Binding ActiveShowcaseType, Converter={converters:ShowcaseTypeToCollapsedVisibilityConverter}, ConverterParameter={x:Static model:ShowcaseType.List}}">
+                <ListView ItemsSource="{Binding Games}"
+                          HorizontalContentAlignment="Stretch"
+                          VerticalContentAlignment="Stretch"
+                          Background="Transparent">
+                    <ListView.View>
+                        <GridView>
+                            <GridViewColumn>
+                                <GridViewColumn.CellTemplate>
+                                    <DataTemplate>
+                                        <Image Width="25" Source="{Binding Icon,
+                                                Converter={StaticResource UriToBitmapImageConverter},
+                                                ConverterParameter=25,
+                                                Mode=OneWay,
+                                                FallbackValue={StaticResource DefaultGameIcon},
+                                                TargetNullValue={StaticResource DefaultGameIcon}}">
+                                        </Image>
+                                    </DataTemplate>
+                                </GridViewColumn.CellTemplate>
+                            </GridViewColumn>
+                            <GridViewColumn>
+                                <GridViewColumnHeader>
+                                    <TextBlock Text="{DynamicResource LOC_PlayNext_MainScoreColumn}" VerticalAlignment="Center" HorizontalAlignment="Center" />
+                                </GridViewColumnHeader>
+                                <GridViewColumn.CellTemplate>
+                                    <DataTemplate>
+                                        <TextBlock Text="{Binding Score, StringFormat=#0.00}" VerticalAlignment="Center" HorizontalAlignment="Center" />
+                                    </DataTemplate>
+                                </GridViewColumn.CellTemplate>
+                            </GridViewColumn>
+                            <GridViewColumn>
+                                <GridViewColumnHeader>
+                                    <TextBlock Text="{DynamicResource LOC_PlayNext_MainNameColumn}" VerticalAlignment="Center" />
+                                </GridViewColumnHeader>
+                                <GridViewColumn.CellTemplate>
+                                    <DataTemplate>
+                                        <TextBlock Text="{Binding Name}" VerticalAlignment="Center" />
+                                    </DataTemplate>
+                                </GridViewColumn.CellTemplate>
+                            </GridViewColumn>
+                            <GridViewColumn>
+                                <GridViewColumn.CellTemplate>
+                                    <DataTemplate>
+                                        <Button Command="{Binding OpenDetails}"  Content="{DynamicResource LOC_PlayNext_MainDetailsButton}"></Button>
+                                    </DataTemplate>
+                                </GridViewColumn.CellTemplate>
+                            </GridViewColumn>
+                        </GridView>
+                    </ListView.View>
+                </ListView>
+            </Grid>
+
+            <Grid Visibility="{Binding ActiveShowcaseType, Converter={converters:ShowcaseTypeToCollapsedVisibilityConverter}, ConverterParameter={x:Static model:ShowcaseType.Covers}}">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="*"></RowDefinition>
+                    <RowDefinition Height="Auto"></RowDefinition>
+                    <RowDefinition Height="*"></RowDefinition>
+                </Grid.RowDefinitions>
+
+                <ListBox Grid.Row="1"  ItemsSource="{Binding TopGames}" Background="Transparent">
+                    <ListBox.ItemContainerStyle>
+                        <Style TargetType="{x:Type ListBoxItem}" BasedOn="{StaticResource {x:Type ListBoxItem}}">
+                            <Setter Property="Focusable" Value="False" />
+                            <Setter Property="Template">
+                                <Setter.Value>
+                                    <ControlTemplate TargetType="{x:Type ListBoxItem}">
+                                        <Border x:Name="Bd" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" Padding="{TemplateBinding Padding}" SnapsToDevicePixels="true">
+                                            <ContentPresenter HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
+                                        </Border>
+                                        <ControlTemplate.Triggers>
+                                            <Trigger Property="IsSelected" Value="true">
+                                                <Setter Property="Background" TargetName="Bd" Value="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}" />
+                                                <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}" />
+                                            </Trigger>
+                                            <MultiTrigger>
+                                                <MultiTrigger.Conditions>
+                                                    <Condition Property="IsSelected" Value="true" />
+                                                    <Condition Property="Selector.IsSelectionActive" Value="false" />
+                                                </MultiTrigger.Conditions>
+                                                <Setter Property="Background" TargetName="Bd" Value="{DynamicResource {x:Static SystemColors.InactiveSelectionHighlightBrushKey}}" />
+                                                <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.InactiveSelectionHighlightTextBrushKey}}" />
+                                            </MultiTrigger>
+                                            <Trigger Property="IsEnabled" Value="false">
+                                                <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}" />
+                                            </Trigger>
+                                            <Trigger Property="IsMouseOver" Value="True">
+                                                <Setter Property="Background" Value="Transparent" />
+                                            </Trigger>
+                                        </ControlTemplate.Triggers>
+                                    </ControlTemplate>
+                                </Setter.Value>
+                            </Setter>
+                        </Style>
+                    </ListBox.ItemContainerStyle>
+                    <ListBox.ItemsPanel>
+                        <ItemsPanelTemplate>
+                            <VirtualizingStackPanel IsItemsHost="True" Orientation="Horizontal" MouseWheel="OnCoversListBoxMouseWheel" />
+                        </ItemsPanelTemplate>
+                    </ListBox.ItemsPanel>
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <Grid>
+                                <Grid.RenderTransform>
+                                    <ScaleTransform  x:Name="HoverTransform" CenterX="150" CenterY="200" ScaleX="1" ScaleY="1" />
+                                </Grid.RenderTransform>
+                                <Grid.Triggers>
+                                    <EventTrigger RoutedEvent="Grid.MouseEnter">
+
+                                        <EventTrigger.Actions>
+                                            <StopStoryboard BeginStoryboardName="hoverStopStoryboard"></StopStoryboard>
+                                            <BeginStoryboard Name="hoverStartStoryboard">
+                                                <Storyboard>
+                                                    <DoubleAnimation
+                                                        Storyboard.TargetName="HoverTransform"
+                                                        Storyboard.TargetProperty="ScaleX"
+                                                        From="1" To="1.05" Duration="0:0:0.1" />
+                                                    <DoubleAnimation
+                                                        Storyboard.TargetName="HoverTransform"
+                                                        Storyboard.TargetProperty="ScaleY"
+                                                        From="1" To="1.05" Duration="0:0:0.1" />
+                                                </Storyboard>
+                                            </BeginStoryboard>
+                                        </EventTrigger.Actions>
+                                    </EventTrigger>
+                                    <EventTrigger RoutedEvent="Grid.MouseLeave">
+                                        <EventTrigger.Actions>
+                                            <StopStoryboard BeginStoryboardName="hoverStartStoryboard"></StopStoryboard>
+                                            <BeginStoryboard Name="hoverStopStoryboard">
+                                                <Storyboard>
+                                                    <DoubleAnimation
+                                                        Storyboard.TargetName="HoverTransform"
+                                                        Storyboard.TargetProperty="ScaleX"
+                                                        From="1.05" To="1" Duration="0:0:0.05" />
+                                                    <DoubleAnimation
+                                                        Storyboard.TargetName="HoverTransform"
+                                                        Storyboard.TargetProperty="ScaleY"
+                                                        From="1.05" To="1" Duration="0:0:0.05" />
+                                                </Storyboard>
+                                            </BeginStoryboard>
+                                        </EventTrigger.Actions>
+                                    </EventTrigger>
+                                </Grid.Triggers>
+
+                                <Button Command="{Binding OpenDetails}" Background="Transparent">
+                                    <Image Height="400" Source="{Binding CoverImage,
+                                        Converter={StaticResource UriToBitmapImageConverter},
+                                        ConverterParameter=400,
+                                        Mode=OneWay,
+                                        FallbackValue={StaticResource DefaultGameCover},
+                                        TargetNullValue={StaticResource DefaultGameCover}}">
                                     </Image>
-                                </DataTemplate>
-                            </GridViewColumn.CellTemplate>
-                        </GridViewColumn>
-                        <GridViewColumn>
-                            <GridViewColumnHeader>
-                                <TextBlock Text="{DynamicResource LOC_PlayNext_MainScoreColumn}" VerticalAlignment="Center" HorizontalAlignment="Center" />
-                            </GridViewColumnHeader>
-                            <GridViewColumn.CellTemplate>
-                                <DataTemplate>
-                                    <TextBlock Text="{Binding Score, StringFormat=#0.00}" VerticalAlignment="Center" HorizontalAlignment="Center" />
-                                </DataTemplate>
-                            </GridViewColumn.CellTemplate>
-                        </GridViewColumn>
-                        <GridViewColumn>
-                            <GridViewColumnHeader>
-                                <TextBlock Text="{DynamicResource LOC_PlayNext_MainNameColumn}" VerticalAlignment="Center" />
-                            </GridViewColumnHeader>
-                            <GridViewColumn.CellTemplate>
-                                <DataTemplate>
-                                    <TextBlock Text="{Binding Name}" VerticalAlignment="Center" />
-                                </DataTemplate>
-                            </GridViewColumn.CellTemplate>
-                        </GridViewColumn>
-                        <GridViewColumn>
-                            <GridViewColumn.CellTemplate>
-                                <DataTemplate>
-                                    <Button Command="{Binding OpenDetails}"  Content="{DynamicResource LOC_PlayNext_MainDetailsButton}"></Button>
-                                </DataTemplate>
-                            </GridViewColumn.CellTemplate>
-                        </GridViewColumn>
-                    </GridView>
-                </ListView.View>
-            </ListView>
+                                </Button>
+                            </Grid>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ListBox>
+            </Grid>
         </Grid>
-
-        <Grid Grid.Row="2"  Visibility="{Binding ActiveShowcaseType, Converter={converters:ShowcaseTypeToCollapsedVisibilityConverter}, ConverterParameter={x:Static model:ShowcaseType.Covers}}">
-            <Grid.RowDefinitions>
-                <RowDefinition Height="*"></RowDefinition>
-                <RowDefinition Height="Auto"></RowDefinition>
-                <RowDefinition Height="*"></RowDefinition>
-            </Grid.RowDefinitions>
-
-            <ListBox Grid.Row="1"  ItemsSource="{Binding TopGames}" Background="Transparent">
-                <ListBox.ItemContainerStyle>
-                    <Style TargetType="{x:Type ListBoxItem}" BasedOn="{StaticResource {x:Type ListBoxItem}}">
-                        <Setter Property="Focusable" Value="False" />
-                        <Setter Property="Template">
-                            <Setter.Value>
-                                <ControlTemplate TargetType="{x:Type ListBoxItem}">
-                                    <Border x:Name="Bd" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" Padding="{TemplateBinding Padding}" SnapsToDevicePixels="true">
-                                        <ContentPresenter HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
-                                    </Border>
-                                    <ControlTemplate.Triggers>
-                                        <Trigger Property="IsSelected" Value="true">
-                                            <Setter Property="Background" TargetName="Bd" Value="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}" />
-                                            <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}" />
-                                        </Trigger>
-                                        <MultiTrigger>
-                                            <MultiTrigger.Conditions>
-                                                <Condition Property="IsSelected" Value="true" />
-                                                <Condition Property="Selector.IsSelectionActive" Value="false" />
-                                            </MultiTrigger.Conditions>
-                                            <Setter Property="Background" TargetName="Bd" Value="{DynamicResource {x:Static SystemColors.InactiveSelectionHighlightBrushKey}}" />
-                                            <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.InactiveSelectionHighlightTextBrushKey}}" />
-                                        </MultiTrigger>
-                                        <Trigger Property="IsEnabled" Value="false">
-                                            <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}" />
-                                        </Trigger>
-                                        <Trigger Property="IsMouseOver" Value="True">
-                                            <Setter Property="Background" Value="Transparent" />
-                                        </Trigger>
-                                    </ControlTemplate.Triggers>
-                                </ControlTemplate>
-                            </Setter.Value>
-                        </Setter>
-                    </Style>
-                </ListBox.ItemContainerStyle>
-                <ListBox.ItemsPanel>
-                    <ItemsPanelTemplate>
-                        <VirtualizingStackPanel IsItemsHost="True" Orientation="Horizontal" MouseWheel="OnCoversListBoxMouseWheel" />
-                    </ItemsPanelTemplate>
-                </ListBox.ItemsPanel>
-                <ItemsControl.ItemTemplate>
-                    <DataTemplate>
-                        <Grid>
-                            <Grid.RenderTransform>
-                                <ScaleTransform  x:Name="HoverTransform" CenterX="150" CenterY="200" ScaleX="1" ScaleY="1" />
-                            </Grid.RenderTransform>
-                            <Grid.Triggers>
-                                <EventTrigger RoutedEvent="Grid.MouseEnter">
-
-                                    <EventTrigger.Actions>
-                                        <StopStoryboard BeginStoryboardName="hoverStopStoryboard"></StopStoryboard>
-                                        <BeginStoryboard Name="hoverStartStoryboard">
-                                            <Storyboard>
-                                                <DoubleAnimation
-                                                    Storyboard.TargetName="HoverTransform"
-                                                    Storyboard.TargetProperty="ScaleX"
-                                                    From="1" To="1.05" Duration="0:0:0.1" />
-                                                <DoubleAnimation
-                                                    Storyboard.TargetName="HoverTransform"
-                                                    Storyboard.TargetProperty="ScaleY"
-                                                    From="1" To="1.05" Duration="0:0:0.1" />
-                                            </Storyboard>
-                                        </BeginStoryboard>
-                                    </EventTrigger.Actions>
-                                </EventTrigger>
-                                <EventTrigger RoutedEvent="Grid.MouseLeave">
-                                    <EventTrigger.Actions>
-                                        <StopStoryboard BeginStoryboardName="hoverStartStoryboard"></StopStoryboard>
-                                        <BeginStoryboard Name="hoverStopStoryboard">
-                                            <Storyboard>
-                                                <DoubleAnimation
-                                                    Storyboard.TargetName="HoverTransform"
-                                                    Storyboard.TargetProperty="ScaleX"
-                                                    From="1.05" To="1" Duration="0:0:0.05" />
-                                                <DoubleAnimation
-                                                    Storyboard.TargetName="HoverTransform"
-                                                    Storyboard.TargetProperty="ScaleY"
-                                                    From="1.05" To="1" Duration="0:0:0.05" />
-                                            </Storyboard>
-                                        </BeginStoryboard>
-                                    </EventTrigger.Actions>
-                                </EventTrigger>
-                            </Grid.Triggers>
-
-                            <Button Command="{Binding OpenDetails}" Background="Transparent">
-                                <Image Height="400" Source="{Binding CoverImage,
-                                    Converter={StaticResource UriToBitmapImageConverter},
-                                    ConverterParameter=400,
-                                    Mode=OneWay,
-                                    FallbackValue={StaticResource DefaultGameCover},
-                                    TargetNullValue={StaticResource DefaultGameCover}}">
-                                </Image>
-                            </Button>
-                        </Grid>
-                    </DataTemplate>
-                </ItemsControl.ItemTemplate>
-            </ListBox>
-        </Grid>
-    </Grid>
+    </DockPanel>
 </PluginUserControl>

--- a/PlayNext/Views/PlayNextMainView.xaml
+++ b/PlayNext/Views/PlayNextMainView.xaml
@@ -97,7 +97,8 @@
                 <ListView ItemsSource="{Binding Games}"
                           HorizontalContentAlignment="Stretch"
                           VerticalContentAlignment="Stretch"
-                          Background="Transparent">
+                          Background="Transparent"
+                          BorderThickness="0">
                     <ListView.View>
                         <GridView>
                             <GridViewColumn>
@@ -152,7 +153,7 @@
                     <RowDefinition Height="*"></RowDefinition>
                 </Grid.RowDefinitions>
 
-                <ListBox Grid.Row="1"  ItemsSource="{Binding TopGames}" Background="Transparent">
+                <ListBox Grid.Row="1"  ItemsSource="{Binding TopGames}" Background="Transparent" BorderThickness="0">
                     <ListBox.ItemContainerStyle>
                         <Style TargetType="{x:Type ListBoxItem}" BasedOn="{StaticResource {x:Type ListBoxItem}}">
                             <Setter Property="Focusable" Value="False" />
@@ -236,7 +237,7 @@
                                     </EventTrigger>
                                 </Grid.Triggers>
 
-                                <Button Command="{Binding OpenDetails}" Background="Transparent">
+                                <Button Command="{Binding OpenDetails}" Background="Transparent" BorderThickness="0">
                                     <Image Height="400" Source="{Binding CoverImage,
                                         Converter={StaticResource UriToBitmapImageConverter},
                                         ConverterParameter=400,

--- a/PlayNext/Views/PlayNextMainView.xaml
+++ b/PlayNext/Views/PlayNextMainView.xaml
@@ -40,49 +40,56 @@
     </PluginUserControl.Resources>
 
     <DockPanel>
-        <StackPanel Orientation="Horizontal" Margin="10,10,0,0" DockPanel.Dock="Top">
-            <TextBlock VerticalAlignment="Center" WindowChrome.IsHitTestVisibleInChrome="True">
-                <Hyperlink Command="{Binding NavigateBackCommand}">
-                    <TextBlock 
-                        Text="&#xea5c;" 
-                        FontFamily="{DynamicResource FontIcoFont}"
-                        FontSize="26" 
-                        Style="{x:Null}" />
-                </Hyperlink>
-            </TextBlock>
-            <TextBlock 
-                Text="{DynamicResource LOC_PlayNext_PluginName}" 
-                Style="{StaticResource BaseTextBlockStyle}"
-                FontSize="18"
-                Margin="10,0,0,0"
-                VerticalAlignment="Center" />
-        </StackPanel>
+        <StackPanel Orientation="Horizontal" Margin="10,10,10,10" DockPanel.Dock="Top">
 
-        <StackPanel Orientation="Horizontal" Margin="0,0,10,0" HorizontalAlignment="Right" DockPanel.Dock="Top">
-            <Button
-                Margin="0,0,10,0"
+            <StackPanel Orientation="Horizontal" Margin="0,0,20,0">
+                <TextBlock VerticalAlignment="Center" WindowChrome.IsHitTestVisibleInChrome="True">
+                    <Hyperlink Command="{Binding NavigateBackCommand}">
+                        <TextBlock 
+                            Text="&#xea5c;" 
+                            FontFamily="{DynamicResource FontIcoFont}"
+                            FontSize="26" 
+                            Style="{x:Null}" />
+                    </Hyperlink>
+                </TextBlock>
+                <TextBlock 
+                    Text="{DynamicResource LOC_PlayNext_PluginName}" 
+                    Style="{StaticResource BaseTextBlockStyle}"
+                    FontSize="18"
+                    Margin="10,0,0,0"
+                    VerticalAlignment="Center" />
+            </StackPanel>
+
+            
+            <Button Margin="0,0,10,0"
                 Width="50"
                 Height="30"
+                WindowChrome.IsHitTestVisibleInChrome="True"
                 Command="{Binding Refresh}"
                 Visibility="{Binding IsRefreshAvailable, Converter={converters:BooleanToCollapsedVisibilityConverter}}">
                 <TextBlock FontFamily="{DynamicResource FontIcoFont}" Text="&#xefd1;"></TextBlock>
             </Button>
-            <Button
-                Margin="0,0,10,0"
-                Width="50"
-                Height="30"
-                Command="{Binding SwitchToCovers}"
-                IsEnabled="{Binding ActiveShowcaseType, Converter={converters:ShowcaseTypeToInvertedBooleanConverter}, ConverterParameter={x:Static model:ShowcaseType.Covers}}">
-                ▋ ▋
-            </Button>
-            <Button
-                Margin="0,0,50,0"
-                Width="50"
-                Height="30"
-                Command="{Binding SwitchToList}"
-                IsEnabled="{Binding ActiveShowcaseType, Converter={converters:ShowcaseTypeToInvertedBooleanConverter}, ConverterParameter={x:Static model:ShowcaseType.List}}">
-                ≡
-            </Button>
+
+            <StackPanel Orientation="Horizontal" Margin="10,0,20,0">
+                <Button
+                    Margin="0,0,10,0"
+                    Width="50"
+                    Height="30"
+                    WindowChrome.IsHitTestVisibleInChrome="True"
+                    Command="{Binding SwitchToCovers}"
+                    IsEnabled="{Binding ActiveShowcaseType, Converter={converters:ShowcaseTypeToInvertedBooleanConverter}, ConverterParameter={x:Static model:ShowcaseType.Covers}}">
+                    ▋ ▋
+                </Button>
+                <Button
+                    Width="50"
+                    Height="30"
+                    WindowChrome.IsHitTestVisibleInChrome="True"
+                    Command="{Binding SwitchToList}"
+                    IsEnabled="{Binding ActiveShowcaseType, Converter={converters:ShowcaseTypeToInvertedBooleanConverter}, ConverterParameter={x:Static model:ShowcaseType.List}}">
+                    ≡
+                </Button>
+            </StackPanel>
+ 
         </StackPanel>
 
         <Grid>

--- a/PlayNext/Views/PlayNextMainView.xaml
+++ b/PlayNext/Views/PlayNextMainView.xaml
@@ -148,6 +148,15 @@
                                     </DataTemplate>
                                 </GridViewColumn.CellTemplate>
                             </GridViewColumn>
+                            <GridViewColumn>
+                                <GridViewColumn.CellTemplate>
+                                    <DataTemplate>
+                                        <Button Command="{Binding ExcludeGame}" ToolTip="Exclude from recommendations">
+                                            <TextBlock Text="✕" FontSize="14" HorizontalAlignment="Center" VerticalAlignment="Center" />
+                                        </Button>
+                                    </DataTemplate>
+                                </GridViewColumn.CellTemplate>
+                            </GridViewColumn>
                         </GridView>
                     </ListView.View>
                 </ListView>

--- a/PlayNext/Views/PlayNextMainView.xaml
+++ b/PlayNext/Views/PlayNextMainView.xaml
@@ -71,23 +71,23 @@
             </Button>
 
             <StackPanel Orientation="Horizontal" Margin="10,0,20,0">
-                <Button
+                <ToggleButton
                     Margin="0,0,10,0"
                     Width="50"
                     Height="30"
                     WindowChrome.IsHitTestVisibleInChrome="True"
                     Command="{Binding SwitchToCovers}"
-                    IsEnabled="{Binding ActiveShowcaseType, Converter={converters:ShowcaseTypeToInvertedBooleanConverter}, ConverterParameter={x:Static model:ShowcaseType.Covers}}">
+                    IsChecked="{Binding ActiveShowcaseType, Mode=OneWay, Converter={converters:ShowcaseTypeToBooleanConverter}, ConverterParameter={x:Static model:ShowcaseType.Covers}}">
                     ▋ ▋
-                </Button>
-                <Button
+                </ToggleButton>
+                <ToggleButton
                     Width="50"
                     Height="30"
                     WindowChrome.IsHitTestVisibleInChrome="True"
                     Command="{Binding SwitchToList}"
-                    IsEnabled="{Binding ActiveShowcaseType, Converter={converters:ShowcaseTypeToInvertedBooleanConverter}, ConverterParameter={x:Static model:ShowcaseType.List}}">
+                    IsChecked="{Binding ActiveShowcaseType, Mode=OneWay, Converter={converters:ShowcaseTypeToBooleanConverter}, ConverterParameter={x:Static model:ShowcaseType.List}}">
                     ≡
-                </Button>
+                </ToggleButton>
             </StackPanel>
  
         </StackPanel>

--- a/PlayNext/Views/PlayNextMainView.xaml
+++ b/PlayNext/Views/PlayNextMainView.xaml
@@ -231,6 +231,10 @@
                                                         Storyboard.TargetName="HoverTransform"
                                                         Storyboard.TargetProperty="ScaleY"
                                                         From="1" To="1.05" Duration="0:0:0.1" />
+                                                    <DoubleAnimation
+                                                        Storyboard.TargetName="ExcludeButton"
+                                                        Storyboard.TargetProperty="Opacity"
+                                                        From="0" To="1" Duration="0:0:0.1" />
                                                 </Storyboard>
                                             </BeginStoryboard>
                                         </EventTrigger.Actions>
@@ -248,6 +252,10 @@
                                                         Storyboard.TargetName="HoverTransform"
                                                         Storyboard.TargetProperty="ScaleY"
                                                         From="1.05" To="1" Duration="0:0:0.05" />
+                                                    <DoubleAnimation
+                                                        Storyboard.TargetName="ExcludeButton"
+                                                        Storyboard.TargetProperty="Opacity"
+                                                        From="1" To="0" Duration="0:0:0.05" />
                                                 </Storyboard>
                                             </BeginStoryboard>
                                         </EventTrigger.Actions>
@@ -262,6 +270,10 @@
                                         FallbackValue={StaticResource DefaultGameCover},
                                         TargetNullValue={StaticResource DefaultGameCover}}">
                                     </Image>
+                                </Button>
+                            
+                                <Button x:Name="ExcludeButton" Command="{Binding ExcludeGame}" VerticalAlignment="Top" HorizontalAlignment="Right" Margin="0,5,8,0" Width="28" Height="28" Padding="0" ToolTip="Exclude from recommendations" Opacity="0">
+                                    <TextBlock Text="✕" FontSize="18" Foreground="White" FontWeight="Bold" />
                                 </Button>
                             </Grid>
                         </DataTemplate>

--- a/PlayNext/Views/PlayNextMainView.xaml
+++ b/PlayNext/Views/PlayNextMainView.xaml
@@ -45,7 +45,12 @@
             <RowDefinition Height="50px"></RowDefinition>
             <RowDefinition Height="*"></RowDefinition>
         </Grid.RowDefinitions>
-        <TextBlock Grid.Row="0" Text="{DynamicResource LOC_PlayNext_PluginName}" Margin="10,30,0,0"></TextBlock>
+        <TextBlock Grid.Row="0" 
+                   Text="{DynamicResource LOC_PlayNext_PluginName}" 
+                   Style="{StaticResource BaseTextBlockStyle}"
+                   FontSize="18"
+                   Margin="10,30,0,0"
+                   VerticalAlignment="Center"></TextBlock>
         <StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Right">
             <Button
                 Margin="0,0,10,0"

--- a/PlayNext/Views/PlayNextMainView.xaml
+++ b/PlayNext/Views/PlayNextMainView.xaml
@@ -41,6 +41,15 @@
 
     <DockPanel>
         <StackPanel Orientation="Horizontal" Margin="10,10,0,0" DockPanel.Dock="Top">
+            <TextBlock VerticalAlignment="Center" WindowChrome.IsHitTestVisibleInChrome="True">
+                <Hyperlink Command="{Binding NavigateBackCommand}">
+                    <TextBlock 
+                        Text="&#xea5c;" 
+                        FontFamily="{DynamicResource FontIcoFont}"
+                        FontSize="26" 
+                        Style="{x:Null}" />
+                </Hyperlink>
+            </TextBlock>
             <TextBlock 
                 Text="{DynamicResource LOC_PlayNext_PluginName}" 
                 Style="{StaticResource BaseTextBlockStyle}"

--- a/PlayNext/Views/PlayNextMainView.xaml
+++ b/PlayNext/Views/PlayNextMainView.xaml
@@ -212,10 +212,7 @@
                     </ListBox.ItemsPanel>
                     <ItemsControl.ItemTemplate>
                         <DataTemplate>
-                            <Grid>
-                                <Grid.RenderTransform>
-                                    <ScaleTransform  x:Name="HoverTransform" CenterX="150" CenterY="200" ScaleX="1" ScaleY="1" />
-                                </Grid.RenderTransform>
+                            <Grid Margin="8,0,0,8">
                                 <Grid.Triggers>
                                     <EventTrigger RoutedEvent="Grid.MouseEnter">
 
@@ -262,18 +259,32 @@
                                     </EventTrigger>
                                 </Grid.Triggers>
 
-                                <Button Command="{Binding OpenDetails}" Background="Transparent" BorderThickness="0">
-                                    <Image Height="400" Source="{Binding CoverImage,
-                                        Converter={StaticResource UriToBitmapImageConverter},
-                                        ConverterParameter=400,
-                                        Mode=OneWay,
-                                        FallbackValue={StaticResource DefaultGameCover},
-                                        TargetNullValue={StaticResource DefaultGameCover}}">
-                                    </Image>
-                                </Button>
-                            
-                                <Button x:Name="ExcludeButton" Command="{Binding ExcludeGame}" VerticalAlignment="Top" HorizontalAlignment="Right" Margin="0,5,8,0" Width="28" Height="28" Padding="0" ToolTip="Exclude from recommendations" Opacity="0">
-                                    <TextBlock Text="✕" FontSize="18" Foreground="White" FontWeight="Bold" />
+                                
+                                <Border RenderTransformOrigin="0.5,0.5" Margin="0,12,12,0"> <!-- inset for exclude button -->
+                                    <Border.RenderTransform>
+                                        <ScaleTransform x:Name="HoverTransform" ScaleX="1" ScaleY="1" />
+                                    </Border.RenderTransform>
+                                    <Button Command="{Binding OpenDetails}" Background="Transparent" BorderThickness="0"
+                                            Padding="0" MinWidth="0" MinHeight="0" FocusVisualStyle="{x:Null}"
+                                            HorizontalContentAlignment="Stretch" VerticalContentAlignment="Stretch"
+                                            Margin="0">
+                                        <Image Height="400" Source="{Binding CoverImage,
+                                            Converter={StaticResource UriToBitmapImageConverter},
+                                            ConverterParameter=400,
+                                            Mode=OneWay,
+                                            FallbackValue={StaticResource DefaultGameCover},
+                                            TargetNullValue={StaticResource DefaultGameCover}}">
+                                        </Image>
+                                    </Button>
+                                </Border>
+
+                                <Button x:Name="ExcludeButton" Command="{Binding ExcludeGame}"
+                                    VerticalAlignment="Top" HorizontalAlignment="Right"
+                                        Width="24" Height="24" Padding="0"
+                                        ToolTip="Exclude from recommendations"
+                                        Opacity="0" Panel.ZIndex="10">
+                                    <TextBlock Text="✕" FontSize="16" Foreground="White" FontWeight="Bold"
+                                               HorizontalAlignment="Center" VerticalAlignment="Center" />
                                 </Button>
                             </Grid>
                         </DataTemplate>

--- a/PlayNext/Views/PlayNextMainView.xaml
+++ b/PlayNext/Views/PlayNextMainView.xaml
@@ -40,9 +40,11 @@
     </PluginUserControl.Resources>
 
     <DockPanel>
+        <!--Header-->
         <StackPanel Orientation="Horizontal" Margin="10,10,10,10" DockPanel.Dock="Top">
-
+            
             <StackPanel Orientation="Horizontal" Margin="0,0,20,0">
+                <!--Back Button-->
                 <TextBlock VerticalAlignment="Center" WindowChrome.IsHitTestVisibleInChrome="True">
                     <Hyperlink Command="{Binding NavigateBackCommand}">
                         <TextBlock 
@@ -52,6 +54,8 @@
                             Style="{x:Null}" />
                     </Hyperlink>
                 </TextBlock>
+
+                <!--Plugin Name Title-->
                 <TextBlock 
                     Text="{DynamicResource LOC_PlayNext_PluginName}" 
                     Style="{StaticResource BaseTextBlockStyle}"
@@ -60,7 +64,7 @@
                     VerticalAlignment="Center" />
             </StackPanel>
 
-            
+            <!--Refresh Button-->
             <Button Margin="0,0,10,0"
                 Width="50"
                 Height="30"
@@ -70,6 +74,7 @@
                 <TextBlock FontFamily="{DynamicResource FontIcoFont}" Text="&#xefd1;"></TextBlock>
             </Button>
 
+            <!--Showcase Type Toggle Buttons-->
             <StackPanel Orientation="Horizontal" Margin="10,0,20,0">
                 <ToggleButton
                     Margin="0,0,10,0"
@@ -92,7 +97,9 @@
  
         </StackPanel>
 
+        <!--Content-->
         <Grid>
+            <!--List Showcase Type-->
             <Grid Visibility="{Binding ActiveShowcaseType, Converter={converters:ShowcaseTypeToCollapsedVisibilityConverter}, ConverterParameter={x:Static model:ShowcaseType.List}}">
                 <ListView ItemsSource="{Binding Games}"
                           HorizontalContentAlignment="Stretch"
@@ -146,6 +153,7 @@
                 </ListView>
             </Grid>
 
+            <!--Covers Showcase Type-->
             <Grid Visibility="{Binding ActiveShowcaseType, Converter={converters:ShowcaseTypeToCollapsedVisibilityConverter}, ConverterParameter={x:Static model:ShowcaseType.Covers}}">
                 <Grid.RowDefinitions>
                     <RowDefinition Height="*"></RowDefinition>

--- a/PlayNext/Views/PlayNextSettingsView.xaml
+++ b/PlayNext/Views/PlayNextSettingsView.xaml
@@ -492,7 +492,7 @@
                 </Grid.RowDefinitions>
                 <TextBlock Grid.Column="0" Grid.Row="0" Text="{DynamicResource LOC_PlayNext_SettingsAllowed}"></TextBlock>
                 <TextBlock Grid.Column="2" Grid.Row="0" Text="{DynamicResource LOC_PlayNext_SettingsExcluded}"></TextBlock>
-                <ListBox Grid.Column="0" Grid.Row="1" ItemsSource="{Binding ExcludedGames.AllowedItems}" SelectedItem="{Binding ExcludedGames.SelectedAllowedItem}">
+                <ListBox Grid.Column="0" Grid.Row="1" ItemsSource="{Binding Games.AllowedItems}" SelectedItem="{Binding Games.SelectedAllowedItem}">
                     <ListBox.ItemTemplate>
                         <DataTemplate>
                             <TextBlock Text="{Binding Name}"></TextBlock>
@@ -507,10 +507,10 @@
                         <RowDefinition Height="Auto"></RowDefinition>
                         <RowDefinition Height="*"></RowDefinition>
                     </Grid.RowDefinitions>
-                    <Button Grid.Row="1" Content="&gt;" Command="{Binding ExcludedGames.ExcludeItemCommand}"></Button>
-                    <Button Grid.Row="3" Content="&lt;" Command="{Binding ExcludedGames.AllowItemCommand}"></Button>
+                    <Button Grid.Row="1" Content="&gt;" Command="{Binding Games.ExcludeItemCommand}"></Button>
+                    <Button Grid.Row="3" Content="&lt;" Command="{Binding Games.AllowItemCommand}"></Button>
                 </Grid>
-                <ListBox Grid.Column="2" Grid.Row="1" ItemsSource="{Binding ExcludedGames.ExcludedItems}" SelectedItem="{Binding ExcludedGames.SelectedExcludedItem}">
+                <ListBox Grid.Column="2" Grid.Row="1" ItemsSource="{Binding Games.ExcludedItems}" SelectedItem="{Binding Games.SelectedExcludedItem}">
                     <ListBox.ItemTemplate>
                         <DataTemplate>
                             <TextBlock Text="{Binding Name}"></TextBlock>
@@ -524,8 +524,8 @@
                         <ColumnDefinition Width="50"></ColumnDefinition>
                     </Grid.ColumnDefinitions>
                     <TextBlock Grid.Column="0" Text="{DynamicResource LOC_PlayNext_SettingsFilter}"></TextBlock>
-                    <TextBox Grid.Column="1" Text="{Binding ExcludedGames.AllowedItemsFilter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"></TextBox>
-                    <Button Grid.Column="2" Content="X" Command="{Binding ExcludedGames.ClearAllowedItemsFilter}"></Button>
+                    <TextBox Grid.Column="1" Text="{Binding Games.AllowedItemsFilter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"></TextBox>
+                    <Button Grid.Column="2" Content="X" Command="{Binding Games.ClearAllowedItemsFilter}"></Button>
                 </Grid>
                 <Grid Grid.Column="2" Grid.Row="2">
                     <Grid.ColumnDefinitions>
@@ -534,8 +534,8 @@
                         <ColumnDefinition Width="50"></ColumnDefinition>
                     </Grid.ColumnDefinitions>
                     <TextBlock Grid.Column="0" Text="{DynamicResource LOC_PlayNext_SettingsFilter}"></TextBlock>
-                    <TextBox Grid.Column="1" Text="{Binding ExcludedGames.ExcludedItemsFilter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"></TextBox>
-                    <Button Grid.Column="2" Content="X" Command="{Binding ExcludedGames.ClearExcludedItemsFilter}"></Button>
+                    <TextBox Grid.Column="1" Text="{Binding Games.ExcludedItemsFilter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"></TextBox>
+                    <Button Grid.Column="2" Content="X" Command="{Binding Games.ClearExcludedItemsFilter}"></Button>
                 </Grid>
             </Grid>
         </TabItem>

--- a/PlayNext/Views/PlayNextSettingsView.xaml
+++ b/PlayNext/Views/PlayNextSettingsView.xaml
@@ -478,5 +478,66 @@
                 </Grid>
             </Grid>
         </TabItem>
+        <TabItem Header="{DynamicResource LOC_PlayNext_SettingsGamesHeader}">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="2*"></ColumnDefinition>
+                    <ColumnDefinition Width="75"></ColumnDefinition>
+                    <ColumnDefinition Width="2*"></ColumnDefinition>
+                </Grid.ColumnDefinitions>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"></RowDefinition>
+                    <RowDefinition Height="*"></RowDefinition>
+                    <RowDefinition Height="Auto"></RowDefinition>
+                </Grid.RowDefinitions>
+                <TextBlock Grid.Column="0" Grid.Row="0" Text="{DynamicResource LOC_PlayNext_SettingsAllowed}"></TextBlock>
+                <TextBlock Grid.Column="2" Grid.Row="0" Text="{DynamicResource LOC_PlayNext_SettingsExcluded}"></TextBlock>
+                <ListBox Grid.Column="0" Grid.Row="1" ItemsSource="{Binding ExcludedGames.AllowedItems}" SelectedItem="{Binding ExcludedGames.SelectedAllowedItem}">
+                    <ListBox.ItemTemplate>
+                        <DataTemplate>
+                            <TextBlock Text="{Binding Name}"></TextBlock>
+                        </DataTemplate>
+                    </ListBox.ItemTemplate>
+                </ListBox>
+                <Grid Column="1" Row="1">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="*"></RowDefinition>
+                        <RowDefinition Height="Auto"></RowDefinition>
+                        <RowDefinition Height="50"></RowDefinition>
+                        <RowDefinition Height="Auto"></RowDefinition>
+                        <RowDefinition Height="*"></RowDefinition>
+                    </Grid.RowDefinitions>
+                    <Button Grid.Row="1" Content="&gt;" Command="{Binding ExcludedGames.ExcludeItemCommand}"></Button>
+                    <Button Grid.Row="3" Content="&lt;" Command="{Binding ExcludedGames.AllowItemCommand}"></Button>
+                </Grid>
+                <ListBox Grid.Column="2" Grid.Row="1" ItemsSource="{Binding ExcludedGames.ExcludedItems}" SelectedItem="{Binding ExcludedGames.SelectedExcludedItem}">
+                    <ListBox.ItemTemplate>
+                        <DataTemplate>
+                            <TextBlock Text="{Binding Name}"></TextBlock>
+                        </DataTemplate>
+                    </ListBox.ItemTemplate>
+                </ListBox>
+                <Grid Grid.Column="0" Grid.Row="2">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"></ColumnDefinition>
+                        <ColumnDefinition Width="*"></ColumnDefinition>
+                        <ColumnDefinition Width="50"></ColumnDefinition>
+                    </Grid.ColumnDefinitions>
+                    <TextBlock Grid.Column="0" Text="{DynamicResource LOC_PlayNext_SettingsFilter}"></TextBlock>
+                    <TextBox Grid.Column="1" Text="{Binding ExcludedGames.AllowedItemsFilter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"></TextBox>
+                    <Button Grid.Column="2" Content="X" Command="{Binding ExcludedGames.ClearAllowedItemsFilter}"></Button>
+                </Grid>
+                <Grid Grid.Column="2" Grid.Row="2">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"></ColumnDefinition>
+                        <ColumnDefinition Width="*"></ColumnDefinition>
+                        <ColumnDefinition Width="50"></ColumnDefinition>
+                    </Grid.ColumnDefinitions>
+                    <TextBlock Grid.Column="0" Text="{DynamicResource LOC_PlayNext_SettingsFilter}"></TextBlock>
+                    <TextBox Grid.Column="1" Text="{Binding ExcludedGames.ExcludedItemsFilter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"></TextBox>
+                    <Button Grid.Column="2" Content="X" Command="{Binding ExcludedGames.ClearExcludedItemsFilter}"></Button>
+                </Grid>
+            </Grid>
+        </TabItem>
     </TabControl>
 </UserControl>


### PR DESCRIPTION
## Summary
- Adds a new filter for excluded games, showing up in the settings view similarly to excluded tags, etc.
- Adds new column to list view with X button to exclude that game.
- Adds X button to the top right corner of hovered covers to exclude that game, and adjusts layout slightly to facilitate this.

## Context
Based on #46 (should merge first)
Includes a12947b (Migrate to SettingsV5), shared with #49 
### Parallel with #49 
Shares the same SettingsV5 migration commit to avoid separate versions/migrations and ordering issues

## UI
<img width="1680" height="989" alt="image" src="https://github.com/user-attachments/assets/9145b5fe-f178-4787-a687-c9bfb457f51d" />
<img width="1680" height="989" alt="image" src="https://github.com/user-attachments/assets/142c155d-4798-4a2f-af34-4a7b2b740f7c" />
